### PR TITLE
fix(native): guard Android 17 directory entry ABI

### DIFF
--- a/app/src/main/cpp/fusehide/hooks/hook_install.cpp
+++ b/app/src/main/cpp/fusehide/hooks/hook_install.cpp
@@ -372,7 +372,26 @@ struct ResolvedHookFeatureOffsets {
     HookResolutionSource getDirectoryEntriesSource = HookResolutionSource::kProfileFallback;
     HookResolutionSource addDirectoryEntriesFromLowerFsSource =
         HookResolutionSource::kProfileFallback;
+    bool usesValueDirectoryEntries = false;
 };
+
+bool UsesValueDirectoryEntries(const ModuleInfo& module) {
+    std::optional<MappedFile> mapped;
+    if (module.path.find("!/") != std::string::npos) {
+        mapped = MapEmbeddedStoredElf(module.path);
+    } else {
+        mapped = MapReadOnlyFile(module.path, module.fileOffset);
+    }
+    if (!mapped.has_value()) {
+        return false;
+    }
+
+    const auto match = FindLargestSymbolContaining(*mapped, "addDirectoryEntriesFromLowerFs");
+    if (!match.has_value() || match->name.find("shared_ptr") != std::string::npos) {
+        return false;
+    }
+    return match->name.find("vectorINS0_14DirectoryEntry") != std::string::npos;
+}
 
 std::optional<uintptr_t> ResolveLargestSymbolOffsetContaining(const ModuleInfo& module,
                                                               std::string_view needle) {
@@ -476,6 +495,7 @@ struct DeviceHookInstallPlan {
     CriticalHookTargetPlan pfReaddir;
     CriticalHookTargetPlan pfReaddirPostfilter;
     CriticalHookTargetPlan pfReaddirplus;
+    bool supportsDirectoryEntryHooks = true;
 };
 
 bool TryInstallInlineHookAt(void* target, void* replacement, void** backup,
@@ -528,6 +548,7 @@ inline constexpr LayoutAnchorDescriptor kLayoutAnchorDescriptors[] = {
 
 ResolvedHookFeatureOffsets ResolveHookFeatureOffsets(const ModuleInfo& module) {
     ResolvedHookFeatureOffsets features;
+    features.usesValueDirectoryEntries = UsesValueDirectoryEntries(module);
     features.isAppAccessiblePathOffset =
         ResolveFirstAvailableSymbolOffset(module, kIsAppAccessiblePathSymbols);
     features.pfLookupOffset = ResolveFirstAvailableSymbolOffset(module, kPfLookupSymbols);
@@ -909,6 +930,14 @@ DeviceHookInstallPlan ResolveDeviceHookInstallPlan(const ModuleInfo& module) {
     installPlan.pfReaddirplus = BuildCriticalHookTargetPlan(
         installPlan.profile.pfReaddirplusOffset, features.pfReaddirplusOffset,
         features.pfReaddirplusSource, derivedFlags.pfReaddirplus);
+    installPlan.supportsDirectoryEntryHooks = !features.usesValueDirectoryEntries;
+
+    if (!installPlan.supportsDirectoryEntryHooks) {
+        __android_log_print(
+            5, kLogTag,
+            "skip directory entry hooks: MediaProvider uses vector<DirectoryEntry> ABI path=%s",
+            module.path.c_str());
+    }
 
     const int safeScore = std::max(bestScore, 0);
     if (resolvedCount == 0) {
@@ -1290,20 +1319,22 @@ void InstallMinimalDebugHooks(const ModuleInfo& module, const FileElfContext& fi
                                    &process.originalOpen, "open");
     InstallFileCompareHookIfNeeded(fileContext.elfInfo, "__open_2", "__open_2", (void*)WrappedOpen2,
                                    &process.originalOpen2, "__open_2");
-    if (process.originalGetDirectoryEntries == nullptr) {
+    if (installPlan.supportsDirectoryEntryHooks && process.originalGetDirectoryEntries == nullptr) {
         TryInstallCriticalHookFromPlan(module, installPlan.getDirectoryEntries,
                                        "GetDirectoryEntries", (void*)WrappedGetDirectoryEntries,
                                        &process.originalGetDirectoryEntries,
                                        "hook GetDirectoryEntries failed");
     }
-    if (process.originalAddDirectoryEntriesFromLowerFs == nullptr) {
+    if (installPlan.supportsDirectoryEntryHooks &&
+        process.originalAddDirectoryEntriesFromLowerFs == nullptr) {
         TryInstallCriticalHookFromPlan(module, installPlan.addDirectoryEntriesFromLowerFs,
                                        "addDirectoryEntriesFromLowerFs",
                                        (void*)WrappedAddDirectoryEntriesFromLowerFs,
                                        &process.originalAddDirectoryEntriesFromLowerFs,
                                        "hook addDirectoryEntriesFromLowerFs failed");
     }
-    if (process.originalAddDirectoryEntriesFromLowerFs == nullptr) {
+    if (installPlan.supportsDirectoryEntryHooks &&
+        process.originalAddDirectoryEntriesFromLowerFs == nullptr) {
         TryInstallCriticalHookFromPlan(module, installPlan.addDirectoryEntriesFromLowerFsThunk,
                                        "addDirectoryEntriesFromLowerFsThunk",
                                        (void*)WrappedAddDirectoryEntriesFromLowerFs,


### PR DESCRIPTION
## Summary

- detect the Android 17 `vector<DirectoryEntry>` ABI from the full `addDirectoryEntriesFromLowerFs` ELF symbol
- skip the two wrappers that still require the older `vector<shared_ptr<DirectoryEntry>>` layout
- keep the final `fuse_reply_buf` filtering and the remaining path hooks active

## Root cause

`GetDirectoryEntries` does not encode its return type in the C++ symbol name. Recent Android 17 MediaProvider builds changed the return container from `vector<shared_ptr<DirectoryEntry>>` to `vector<DirectoryEntry>`, so the old wrapper could still resolve and install successfully while interpreting value entries as shared pointers. For an `Android` entry this produced the invalid pointer-like value `0x64696f72646e410e` seen in the tombstones.

This is reproducible on both Android 17 QPR2 Beta 2 (`CP41.260717.006`) and the August Android Canary build (`ZP11.260717.006`). FuseFixer is unaffected because it does not hook this directory enumeration chain.

## Verification

- `./gradlew.bat assembleDebug -x spotlessCheck -x spotlessCppCheck`
- installed and tested on Pixel 9 Pro running `ZP11.260717.006`
- reporter confirmed the MediaProvider crash no longer reproduces

Fixes #46
